### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM composer:latest
+
+RUN composer global require squizlabs/php_codesniffer && \
+    composer global require greynoise-design/laravel-coding-standard && \
+    echo "#!/usr/bin/env sh" > /usr/local/bin/phpcs-laravel && \
+    echo 'phpcs $@ --standard=GreynoiseLaravel' >> /usr/local/bin/phpcs-laravel && \
+    echo "#!/usr/bin/env sh" > /usr/local/bin/phpcbf-laravel && \
+    echo 'phpcbf $@ --standard=GreynoiseLaravel' >> /usr/local/bin/phpcbf-laravel && \
+    chmod 777 /usr/local/bin/phpcs-laravel /usr/local/bin/phpcbf-laravel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM composer:latest
 
-RUN composer global require squizlabs/php_codesniffer && \
-    composer global require greynoise-design/laravel-coding-standard && \
-    echo "#!/usr/bin/env sh" > /usr/local/bin/phpcs-laravel && \
-    echo 'phpcs $@ --standard=GreynoiseLaravel' >> /usr/local/bin/phpcs-laravel && \
-    echo "#!/usr/bin/env sh" > /usr/local/bin/phpcbf-laravel && \
-    echo 'phpcbf $@ --standard=GreynoiseLaravel' >> /usr/local/bin/phpcbf-laravel && \
-    chmod 777 /usr/local/bin/phpcs-laravel /usr/local/bin/phpcbf-laravel
+ENV COMPOSER_HOME=/usr/local/composer
+
+RUN composer global require squizlabs/php_codesniffer greynoise-design/laravel-coding-standard && \
+    echo '#!/usr/bin/env sh' > /usr/local/bin/phpcs-laravel && \
+    echo 'phpcs $@ --standard=/usr/local/composer/vendor/greynoise-design/laravel-coding-standard/GreynoiseLaravel/ruleset.xml' >> /usr/local/bin/phpcs-laravel && \
+    echo '#!/usr/bin/env sh' > /usr/local/bin/phpcbf-laravel && \
+    echo 'phpcbf $@ --standard=/usr/local/composer/vendor/greynoise-design/laravel-coding-standard/GreynoiseLaravel/ruleset.xml' >> /usr/local/bin/phpcbf-laravel && \
+    chmod 777 /usr/local/bin/phpcs-laravel /usr/local/bin/phpcbf-laravel && \
+    ln -s /usr/local/composer/vendor/bin/phpcs /usr/local/bin/phpcs && \
+    ln -s /usr/local/composer/vendor/bin/phpcbf /usr/local/bin/phpcbf

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Version 1.0.2
 | :---: | :---: |
 | [![Build Status](https://travis-ci.org/greynoise-design/laravel-coding-standard.svg?branch=master)](https://travis-ci.org/greynoise-design/laravel-coding-standard) | [![Build Status](https://travis-ci.org/greynoise-design/laravel-coding-standard.svg?branch=develop)](https://travis-ci.org/greynoise-design/laravel-coding-standard) |
 | [![Coverage Status](https://coveralls.io/repos/github/greynoise-design/laravel-coding-standard/badge.svg?branch=master)](https://coveralls.io/github/greynoise-design/laravel-coding-standard?branch=master) | [![Coverage Status](https://coveralls.io/repos/github/greynoise-design/laravel-coding-standard/badge.svg?branch=develop)](https://coveralls.io/github/greynoise-design/laravel-coding-standard?branch=develop) |
-
+| [![Docker Pulls](https://img.shields.io/docker/pulls/greynoise-design/laravel-coding-standard.svg)](https://hub.docker.com/r/greynoise-design/laravel-coding-standard/) |  |
 
 ## Requirements
 
@@ -93,6 +93,16 @@ Directory (recursive).
 or if globally installed.
 
 `phpcbf /Path/To/MyProject --standard=GreynoiseLaravel`
+
+#### Using from docker container
+
+If you don't use any CI service, you probably don't need to know how to use this library with docker.
+
+To run syntax test from current folder you need to execute such command:
+`docker run -d greynoise-design/laravel-coding-standard -v ./:/app /bin/sh -c "cd /app; phpcs-laravel -p ."`
+
+To fix syntax for current folder you need to execute similar command:
+`docker run -d greynoise-design/laravel-coding-standard -v ./:/app /bin/sh -c "cd /app; phpcbf-laravel -p ."`
 
 ## Example editor configs
 
@@ -181,4 +191,56 @@ Set it to your preference.
         }
     }
 }
+```
+## Example how to use for CI services
+
+### Gitlab CI
+
+```yaml
+stages:
+  - install
+  - test
+
+composer_install:
+  stage: install
+  image: composer:latest
+  tags:
+    - infrastructure
+  cache:
+    key: ${CI_COMMIT_REF_SLUG}-composer
+    paths:
+      - vendor/
+  artifacts:
+    name: ${CI_COMMIT_SHA}-php
+    expire_in: 1 hour
+    paths:
+      - vendor/
+      - bootstrap/cache/
+  script:
+    - composer install --no-ansi --ignore-platform-reqs --no-interaction --no-progress --optimize-autoloader --no-dev
+    
+phpcs:
+  stage: test
+  image: greynoise-design/laravel-coding-standard:latest
+  tags:
+    - infrastructure
+  script:
+    - phpcs-laravel -p .
+```
+
+### Travis
+
+```yaml
+sudo: required
+
+language: php
+
+services:
+  - docker
+
+before_install:
+  - docker pull greynoise-design/laravel-coding-standard
+
+script:
+  - docker run -d greynoise-design/laravel-coding-standard -v ./:/app /bin/sh -c "cd /app; phpcs-laravel -p ."
 ```

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Set it to your preference.
 ```
 ## Example how to use for CI services
 
-### Gitlab CI
+### .gitlab-ci.yml
 
 ```yaml
 stages:
@@ -228,7 +228,7 @@ phpcs:
     - phpcs-laravel -p .
 ```
 
-### Travis
+### .travis.yml
 
 ```yaml
 sudo: required

--- a/README.md
+++ b/README.md
@@ -204,8 +204,6 @@ stages:
 composer_install:
   stage: install
   image: composer:latest
-  tags:
-    - infrastructure
   cache:
     key: ${CI_COMMIT_REF_SLUG}-composer
     paths:
@@ -222,8 +220,6 @@ composer_install:
 phpcs:
   stage: test
   image: greynoise-design/laravel-coding-standard:latest
-  tags:
-    - infrastructure
   script:
     - phpcs-laravel -p .
 ```


### PR DESCRIPTION
Thank you for your project!

This pull request adds possibility for building docker images that could be used with CI services like Travis or GitlabCI. I have included some examples below how to do that. Of course these examples could work first you need to go to http://hub.docker.com -> *Create* -> *Create automated build* -> *Create auto-build GitHub* and there select your repository. Than add `greynoise-design/laravel-coding-standard`  as docker repo name.  After that every time new laravel-coding-standard version will be released new docker image also will be generated.

I hope I wrote clear enough what is this and this can be useful for other people to use and include in your project.